### PR TITLE
A fix for https://github.com/rebus-org/Rebus.SignalR/issues/3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,5 +6,8 @@
 ## 0.0.3
 * Fix log message typo and improve code readability - thanks [rsivanov]
 
+## 0.0.4
+* Added MapSignalRCommands<THub> extension to support decentralized subscription storages - thanks [rsivanov]
+
 [rsivanov]: https://github.com/rsivanov
 

--- a/Rebus.SignalR/Config/SignalRTypeBasedRouterConfigurationExtensions.cs
+++ b/Rebus.SignalR/Config/SignalRTypeBasedRouterConfigurationExtensions.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.AspNetCore.SignalR;
+using Rebus.Routing.TypeBased;
+using Rebus.SignalR.Contracts;
+
+namespace Rebus.Config
+{
+	/// <summary>
+	/// Configuration extensions for TypeBased router
+	/// </summary>
+	public static class SignalRTypeBasedRouterConfigurationExtensions
+	{
+		/// <summary>
+		/// Map SignalR backplane commands to the destination address
+		/// </summary>
+		/// <param name="configurationBuilder"></param>
+		/// <param name="destinationAddress"></param>
+		/// <typeparam name="THub"></typeparam>
+		/// <returns></returns>
+		public static TypeBasedRouterConfigurationExtensions.TypeBasedRouterConfigurationBuilder MapSignalRCommands<THub>(
+				this TypeBasedRouterConfigurationExtensions.TypeBasedRouterConfigurationBuilder configurationBuilder, string destinationAddress)
+			where THub: Hub
+		{
+			configurationBuilder.Map<AddToGroup<THub>>(destinationAddress);
+			configurationBuilder.Map<RemoveFromGroup<THub>>(destinationAddress);
+			configurationBuilder.Map<All<THub>>(destinationAddress);
+			configurationBuilder.Map<Connection<THub>>(destinationAddress);
+			configurationBuilder.Map<Group<THub>>(destinationAddress);
+			configurationBuilder.Map<User<THub>>(destinationAddress);
+			return configurationBuilder;
+		}
+	}
+}


### PR DESCRIPTION
Added MapSignalRCommands<THub> extension to support decentralized subscription storages

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
