### PR TITLE
Update rebus dependencies

### DIFF
--- a/Rebus.SignalR/Rebus.SignalR.csproj
+++ b/Rebus.SignalR/Rebus.SignalR.csproj
@@ -56,7 +56,7 @@
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="rebus" Version="6.0.1" />
-		<PackageReference Include="Rebus.Async" Version="7.1.0" />
+    <PackageReference Include="rebus" Version="6.6.1" />
+    <PackageReference Include="Rebus.Async" Version="7.2.0" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
Update rebus to 6.6.1.
Update Rebus.Async to 7.2.0.

Last release of Rebus.Async (7.2.0) breaks applications based on Rebus.SignalR, because of changes made to rebus (still based on old 6.0.1 version). These changes fix "Could not load file or assembly 'Rebus.Async, Version=7.1.0.0, Culture=neutral, PublicKeyToken=null'. The system cannot find the file specified." error.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
