### PR TITLE
Update rebus dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,23 @@
 # Changelog
 
 ## 0.0.2
-* Initial version - thanks [rsivanov]
+
+- Initial version - thanks [rsivanov]
 
 ## 0.0.3
-* Fix log message typo and improve code readability - thanks [rsivanov]
+
+- Fix log message typo and improve code readability - thanks [rsivanov]
 
 ## 0.0.4
-* Added MapSignalRCommands<THub> extension to support decentralized subscription storages - thanks [rsivanov]
+
+- Added MapSignalRCommands<THub> extension to support decentralized subscription storages - thanks [rsivanov]
 
 ## 0.0.5
-* Unsubscribe from backplane events through BusLifetimeEvents resolved from DI container
+
+- Unsubscribe from backplane events through BusLifetimeEvents resolved from DI container
+
+## 0.0.6
+
+- Update rebus and Rebus.Async dependencies versions
 
 [rsivanov]: https://github.com/rsivanov
-

--- a/Rebus.SignalR/Rebus.SignalR.csproj
+++ b/Rebus.SignalR/Rebus.SignalR.csproj
@@ -12,7 +12,7 @@
 		-->
 		<TargetFramework>netcoreapp3.1</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
-		<AssemblyVersion>0.0.5</AssemblyVersion>
+		<AssemblyVersion>0.0.6</AssemblyVersion>
 		<Authors>mookid8000,rsivanov</Authors>
 		<PackageVersion>$(AssemblyVersion)</PackageVersion>
 		<PackageLicenseUrl>https://raw.githubusercontent.com/rebus-org/Rebus/master/LICENSE.md</PackageLicenseUrl>

--- a/Rebus.SignalR/Rebus.SignalR.csproj
+++ b/Rebus.SignalR/Rebus.SignalR.csproj
@@ -56,7 +56,7 @@
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="rebus" Version="6.0.1" />
-		<PackageReference Include="Rebus.Async" Version="7.1.0" />
+		<PackageReference Include="rebus" Version="6.6.1" />
+		<PackageReference Include="Rebus.Async" Version="7.2.0" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
Update rebus to 6.6.1.
Update Rebus.Async to 7.2.0.

Last release of Rebus.Async (7.2.0) breaks applications based on Rebus.SignalR, because of changes made to rebus (Rebus.SignlaR is still based on old 6.0.1 version). These changes fix "Could not load file or assembly 'Rebus.Async, Version=7.1.0.0, Culture=neutral, PublicKeyToken=null'. The system cannot find the file specified." error.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
